### PR TITLE
Migrate to Circle CI v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This action can used to trigger a Circle CI job defined in the ```./circleci/con
 
 1. circle_ci_token: The circle ci token to access the circle-ci API.
 2. circle_ci_project_url: This is URL of the project. In your github action you can pass this by using ${{ github.ref }} as the argument.
-3. circle_ci_job_params: A list of coma separated key-value items to pass along in the request to cirlce CI as parameters. These will be used in your Circle CI YML to decide what workflows to run using filtering (`require`, `when`, `unless`, `filter`, etc.)
+3. circle_ci_job_params: A list of coma separated key-value items to pass along in the request to cirlce CI as parameters. These will be used in your Circle CI YML to decide what workflows to run using filtering (`require`, `when`, `filter`, etc.)
+
+Note that with V2 of the Circle CI api, you need to define in your `config.yml` the parameters yourworkflows can recieve and based on them filter out jobs and workflows you want to run. 
 
 An example github workflow file is shown below:
 **Example:** Trigger a build on adding a new label to your pull request.
@@ -26,7 +28,7 @@ jobs:
       uses: Open-Source-Contrib/circle-ci-trigger-action@latest
       with:
         circle_ci_token: ${{ secrets.CIRCLE_CI_TOKEN }}
-        circle_ci_job: ${{ secrets.CIRCLE_CI_QA_JOB }}
+        circle_ci_job_params: "\"jobName\":QA"
         circle_ci_project_url: ${{ github.event.pull_request.head.ref }}
     # Use the output from the `hello` step
     - name: Get the output response
@@ -52,7 +54,7 @@ jobs:
       uses: Open-Source-Contrib/circle-ci-trigger-action@latest
       with:
         circle_ci_token: ${{ secrets.CIRCLE_CI_TOKEN }}
-        circle_ci_job: ${{ secrets.CIRCLE_CI_RELEASE_JOB }}
+        circle_ci_job_params: "\"jobName\":QA_RELEASE"
         circle_ci_project_url: ${{ github.ref }}
     # Use the output from the `curl-circle-ci` step
     - name: Get the output response

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This action can used to trigger a Circle CI job defined in the ```./circleci/config.yml``` file in your repository. The action needs the below listed 3 parameters.
 
 1. circle_ci_token: The circle ci token to access the circle-ci API.
-2. circle_ci_job: The circle ci job to be run. This is defined under the jobs section in ```./circleci/config.yml``` file in your repository.
-3. circle_ci_project_url: This is URL of the project. In your github action you can pass this by using ${{ github.ref }} as the argument.
+2. circle_ci_project_url: This is URL of the project. In your github action you can pass this by using ${{ github.ref }} as the argument.
+3. circle_ci_job_params: A list of coma separated key-value items to pass along in the request to cirlce CI as parameters. These will be used in your Circle CI YML to decide what workflows to run using filtering (`require`, `when`, `unless`, `filter`, etc.)
 
 An example github workflow file is shown below:
 **Example:** Trigger a build on adding a new label to your pull request.

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 # action.yml
-name: 'Run Circle-CI on Label'
+name: 'Run Circle-CI on Label - Circle API v2'
 description: 'Runs a Circle-CI Build upon adding a new label to PR'
 inputs:
   circle_ci_token:  # secret token for circle CI Rest API

--- a/action.yml
+++ b/action.yml
@@ -6,18 +6,18 @@ inputs:
     description: 'Token for Circle-CI'
     required: true
     default: ''
-  circle_ci_job:
-    description: 'Name of the circle-ci-job'
-    required: true
-    default: ''
   circle_ci_project_url:
     description: 'URL for circle-ci project'
     required: true
+    default: ''
+  circle_ci_job_params:
+    description: 'List of params to pass along to circle api. ex: "Param1":"Value1", "Param2":"Value2"'
+    required: false
     default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
     - ${{ inputs.circle_ci_token }}
-    - ${{ inputs.circle_ci_job }}
     - ${{ inputs.circle_ci_project_url }}
+    - ${{ inputs.circle_ci_job_params }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 echo "Running QA workflow for PR created for project $2 branch"
 echo "Request url: https://circleci.com/api/v2/project/gh/$GITHUB_REPOSITORY/pipeline"
 echo "Params: {$3}"
-echo "Key $1"
+
 response=$(curl -X POST "https://circleci.com/api/v2/project/gh/$GITHUB_REPOSITORY/pipeline" \
             -H "Circle-Token: $1" \
             -H "Content-Type: application/json" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,7 @@
 echo "Running QA workflow for PR created for project $2 branch"
 echo "Request url: https://circleci.com/api/v2/project/gh/$GITHUB_REPOSITORY/pipeline"
 echo "Params: {$3}"
+echo "Key $1"
 response=$(curl -X POST "https://circleci.com/api/v2/project/gh/$GITHUB_REPOSITORY/pipeline" \
             -H "Circle-Token: $1" \
             -H "Content-Type: application/json" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,12 @@
 #!/bin/sh -l
 echo "Running QA workflow for PR created on $3 branch"
-project="https://circleci.com/api/v1.1/project/github/$GITHUB_REPOSITORY/tree/$3"
-echo "Running the $2 job for $project"
-response=$(curl -u $1: -d build_parameters[CIRCLE_JOB]=$2 $project)
+response=$(curl -X POST "https://circleci.com/api/v2/project/gh/$GITHUB_REPOSITORY/pipeline" \
+            -H "Circle-Token: $1" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"branch\": \"$2\",
+              \"parameters\": {$3}
+            }")
 output=$?
 echo $response
 echo ::set-output name=response::$output

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -l
-echo "Running QA workflow for PR created on $2 branch"
-
+echo "Running QA workflow for PR created for project $2 branch"
+echo "Request url: https://circleci.com/api/v2/project/gh/$GITHUB_REPOSITORY/pipeline"
 echo "Params: {$3}"
 response=$(curl -X POST "https://circleci.com/api/v2/project/gh/$GITHUB_REPOSITORY/pipeline" \
             -H "Circle-Token: $1" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -l
-echo "Running QA workflow for PR created on $3 branch"
+echo "Running QA workflow for PR created on $2 branch"
+
+echo "Params: {$3}"
 response=$(curl -X POST "https://circleci.com/api/v2/project/gh/$GITHUB_REPOSITORY/pipeline" \
             -H "Circle-Token: $1" \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
I have updated the shell script to use the newer version of the circle ci api.  The new API doesn't support specifying the job to run directly, but allows running workflows and passing parameters to them. Those parameters can be used to filter out jobs to run.

For the github action, this meant removing the job name argument from the github action and replace it with a generic `circle_ci_job_params` argument.